### PR TITLE
Install nose-watch in development mode

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,6 @@
 envlist = py26, py27
 
 [testenv]
+usedevelop=True
 commands = python setup.py nosetests
 


### PR DESCRIPTION
The nose-watch will be installed in development mode into
tox virtual environmets. This is very useful for development.