### PR TITLE
Fix multiple runs

### DIFF
--- a/nosewatch/plugin.py
+++ b/nosewatch/plugin.py
@@ -19,7 +19,7 @@ class WatchPlugin(Plugin):
         argv.remove('--with-watch')
         watchcmd = 'clear && ' + ' '.join(argv)
         call_args = ['watchmedo', 'shell-command', '-c',
-            watchcmd, '-R', '-p', '*.py', '.']
+            watchcmd, '-R', '-p', '*.py', '-W', '.']
         try:
             self.call(call_args)
         except KeyboardInterrupt:


### PR DESCRIPTION
I use django_nose on django 1.9. I run tests with `./manage.py test --with-watch` and after one change i get "quad" run tests.  With `-w`(lower) it's still so, but runs in sequence.